### PR TITLE
Update the code for the old panel

### DIFF
--- a/src/mwToolbar.js
+++ b/src/mwToolbar.js
@@ -6,17 +6,11 @@ function toPromise(deferred) {
    });
 };
 
-export function isToolbarEnabled() {
-   return mw.user.options.get('showtoolbar') === 1;
-};
-
 export function isNewToolbar() {
    return mw.user.options.get('usebetatoolbar') === 1;
 };
 
-export async function addOldToolbarButton(cb, title, icon) {
-   await toPromise($.when(mw.loader.using('mediawiki.toolbar'), $.ready));
-
+export function addOldToolbarButton(cb, title, icon) {
    let $toolbar = $('#gadget-toolbar');
    if (!$toolbar.length) {
       $toolbar = $('#toolbar');

--- a/src/replacer.js
+++ b/src/replacer.js
@@ -104,14 +104,13 @@ async function init() {
       );
       $interwiki.init();
    } else {
-      if (mwToolbar.isToolbarEnabled()) {
-         await mwToolbar.addOldToolbarButton(showDialog, title, icon);
-      } else {
-         mw.util.addPortletLink('p-tb', '#', title).addEventListener('click', function(ev) {
-            ev.preventDefault();
-            showDialog();
-         });
-      }
+      mw.util.addPortletLink('p-tb', '#', title).addEventListener('click', function(ev) {
+         ev.preventDefault();
+         showDialog();
+      });
+      mw.hook('legacy.toolbar.ready').add(function() {
+         mwToolbar.addOldToolbarButton(showDialog, title, icon);
+      });
    }
 };
 


### PR DESCRIPTION
'showtoolbar' option and 'mediawiki.toolbar' module are dropped. Old toolbar is now dependent on the 'legacy.toolbar.ready' hook. We can't know if it will run before it does, so it doesn't override adding the portlet link.